### PR TITLE
ci: restrict postgres port to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=rhcsa_db
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
Prevent external access to the postgres service by binding it to localhost only. This improves security by ensuring the database is only accessible from within the host machine.